### PR TITLE
Add flat/truncated teardrop module

### DIFF
--- a/teardrop.scad
+++ b/teardrop.scad
@@ -36,6 +36,17 @@ module teardrop(radius, length, angle) {
 	*/
 }
 
+module flat_teardrop(radius, length, angle) {
+	intersection() {
+		rotate([0, angle, 0]) {
+			translate([-radius,-radius,0])
+			cube(size=[radius * 2, radius * 2, length]);
+		}
+		teardrop(radius, length, angle);
+	}
+}
+
+
 module test_teardrop(){
     translate([0, -15, 0]) teardrop(5, 20, 90);
     translate([0, 0, 0]) teardrop(5, 20, 60);


### PR DESCRIPTION
Simple intersection method to implement a flat/truncated teardrop (technique gathered from comments made by whosawhatsis on various forums/blogs).
