### PR TITLE
Alu plates for nema motors

### DIFF
--- a/stepper.scad
+++ b/stepper.scad
@@ -131,7 +131,7 @@ Nema17 = [
                 [NemaLengthLong, 47*mm],
                 [NemaSideSize, 42.20*mm], 
                 [NemaDistanceBetweenMountingHoles, 31.04*mm], 
-                [NemaMountingHoleDiameter, 4*mm], 
+                [NemaMountingHoleDiameter, 3*mm],
                 [NemaMountingHoleDepth, 4.5*mm], 
                 [NemaMountingHoleLip, -1*mm], 
                 [NemaMountingHoleCutoutRadius, 0*mm], 


### PR DESCRIPTION
The first commit adds code to draw NEMA motors made of three parts: black steel stator and to thick aluminum plates. The next one fixes indentation after removal of the color() module around the whole solid.
