### PR TITLE
improve imprecise constant for hexagon shape

### DIFF
--- a/shapes.scad
+++ b/shapes.scad
@@ -82,7 +82,7 @@ module ovalTube(height, rx, ry, wall, center = false) {
 
 // size is the XY plane size, height in Z
 module hexagon(size, height) {
-  boxWidth = size/1.75;
+  boxWidth = (size / 2.) / cos(30.);
   for (r = [-60, 0, 60]) rotate([0,0,r]) cube([boxWidth, size, height], true);
 }
 


### PR DESCRIPTION
1.75 is a very bad aproximation for 1.732050807568877 = cos(30) * 2. I don't think we need to optimize here and hardcode the constant - better use a readable calculation.